### PR TITLE
Verticle compilation Error breaks hot deployment flow

### DIFF
--- a/plugin/src/main/java/io/dazraf/vertx/maven/HotDeploy.java
+++ b/plugin/src/main/java/io/dazraf/vertx/maven/HotDeploy.java
@@ -110,7 +110,8 @@ public class HotDeploy {
 
   private void markRedeployed() {
     long nanos = System.nanoTime() - startTime;
-    logger.info("Compiled and redeployed in {}s", String.format("%1.3f", nanos * 1E-9));
+    String status = currentDeployment.get() != null ? "Compiled and redeployed" : "Deployment failed";
+    logger.info("{} in {}s", status, String.format("%1.3f", nanos * 1E-9));
   }
 
   private void loadApp(List<String> classPaths) {


### PR DESCRIPTION
If there's a compilation error in a lambda expression inside a Verticle, this isn't detected until the Vertx.deployVerticle call, when the lambda is processed by the JVM and the Verticle class is instantiated by Vertx. This throws a java.lang.Error with the message "Unresolved compilation problem", which is not caught until it bubbles up to RX Observable's onError callback, killing the file watch and stopping any further hot deployments.

Whilst the JVM is throwing a java.lang.Error in Vertx code, this is one case where we'd rather it was handled to avoid having to kill and restart vertx:hot.

Here's a crude approach that "works for me".
