### PR TITLE
Log exceptions during Verticle deployments

### DIFF
--- a/plugin/src/main/java/io/dazraf/vertx/maven/VerticleDeployer.java
+++ b/plugin/src/main/java/io/dazraf/vertx/maven/VerticleDeployer.java
@@ -68,6 +68,9 @@ public class VerticleDeployer implements Closeable {
     CountDownLatch latch = new CountDownLatch(1);
     try {
       vertx.deployVerticle(verticleClassName, deploymentOptions, ar -> {
+        if (ar.failed()) {
+          logger.error("on deploying verticle {}", verticleClassName, ar.cause());	
+        }
         verticleId.set(ar.result());
         latch.countDown();
       });
@@ -75,7 +78,7 @@ public class VerticleDeployer implements Closeable {
     } catch(Error err) {
       // Vertx throws a generic java.lang.Error on Verticle compilation failure
       if (!(err instanceof VirtualMachineError)) {
-        logger.error("on deploying verticle", err);
+        logger.error("on compiling verticle {}", verticleClassName, err);
         verticleId.set(null);
       } else {
         throw err;


### PR DESCRIPTION
Just a minor niggle: providing a CompletionHandler to Vertx suppresses error logging when an Exception is thrown by a Verticle during deployment. Thus, to avoid the Exception being swallowed, the CompletionHandler has to log it itself.
